### PR TITLE
Option to serve stale content for a cached_include in case of errors.

### DIFF
--- a/lib/lesmok/config.rb
+++ b/lib/lesmok/config.rb
@@ -8,7 +8,6 @@ module Lesmok
     attr_accessor :debugging_enabled
     attr_accessor :raise_errors_enabled
 
-    alias :serve_stale_content? :serve_stale_content
     alias :raise_errors? :raise_errors_enabled
     alias :debugging? :debugging_enabled
 
@@ -21,8 +20,11 @@ module Lesmok
     end
 
     def caching?
-      return false if !@caching_enabled
-      @caching_enabled.kind_of?(Proc) ? @caching_enabled.call : true
+      check_dynamically_toggleable_setting(@caching_enabled)
+    end
+
+    def serve_stale_content?
+      check_dynamically_toggleable_setting(@serve_stale_content)
     end
 
     def find_cache_store(name = nil)
@@ -35,6 +37,18 @@ module Lesmok
 
     def rails?
       Object.const_defined? "Rails"
+    end
+
+
+    protected
+
+    ##
+    # Some settings can be changed at run-time from other parts of the system.
+    # Allow setting a `proc` to check this each time.
+    #
+    def check_dynamically_toggleable_setting(toggleable)
+      return false if !toggleable
+      toggleable.kind_of?(Proc) ? toggleable.call : true
     end
 
   end

--- a/lib/lesmok/config.rb
+++ b/lib/lesmok/config.rb
@@ -3,10 +3,12 @@ module Lesmok
     attr_accessor :logger
     attr_accessor :cache
     attr_accessor :caching_enabled
+    attr_accessor :serve_stale_content
     attr_accessor :available_cache_stores
     attr_accessor :debugging_enabled
     attr_accessor :raise_errors_enabled
 
+    alias :serve_stale_content? :serve_stale_content
     alias :raise_errors? :raise_errors_enabled
     alias :debugging? :debugging_enabled
 

--- a/lib/lesmok/tags/cached_include.rb
+++ b/lib/lesmok/tags/cached_include.rb
@@ -47,7 +47,7 @@ module Lesmok
           result = cache_store.fetch(cache_key, expires_in: expire_in) do
             lesmok_logger.debug "[#{self.class}] --- cache miss on #{cache_key} in #{cache_store}!" if Lesmok.config.debugging?
             rendered_str = yield
-            if Lesmok.config.serve_stale_content? && rendered_str.present?
+            if Lesmok.config.serve_stale_content? && rendered_str.present? && context.errors.empty?
               stale_cache_store = select_cache_store_for(context, :stale)
               stale_cache_store.set(cache_key + STALE_BREAD_KEY_SUFFIX, rendered_str, expires_in: nil)
             end

--- a/lib/lesmok/tags/cached_include.rb
+++ b/lib/lesmok/tags/cached_include.rb
@@ -29,16 +29,6 @@ module Lesmok
           result = perform_cached_inclusion_rendering_for(context, cache_store, cache_key) do
             super
           end
-          lesmok_logger.debug "[#{self.class}] Lookup #{cache_key} in #{cache_store}..." if Lesmok.config.debugging?
-          result = cache_store.fetch(cache_key, expires_in: expire_in) do
-            lesmok_logger.debug "[#{self.class}] --- cache miss on #{cache_key} in #{cache_store}!" if Lesmok.config.debugging?
-            rendered_str = super
-            if Lesmok.config.serve_stale_content? && rendered_str.present?
-              stale_cache_store = select_cache_store_for(context, :stale)
-              stale_cache_store.set(cache_key + STALE_BREAD_KEY_SUFFIX, rendered_str, expires_in: nil)
-            end
-            rendered_str
-          end
 
           if context.errors.present?
             lesmok_logger.debug "[lesmok] -- Liquid errors (#{context.errors.size}) seen in: #{template_name}"


### PR DESCRIPTION
TODO:
- Possible to check if sub-templates have been served with cache? Want to avoid inadvertently storing bad results in long-term cache at higher level, but can't throw the exceptions up the stack.
