### PR TITLE
Use a weak reference to memoize the liquid drop from the source object.

### DIFF
--- a/lib/lesmok/acid/meltable.rb
+++ b/lib/lesmok/acid/meltable.rb
@@ -1,3 +1,4 @@
+require 'weakref'
 module Lesmok
   module Acid
 
@@ -20,7 +21,12 @@ module Lesmok
 
         ## Liquify...
         def to_liquid
-          @liquid_drop ||= liquify_dynamically
+          drop = @weak_liquid_drop && @weak_liquid_drop.weakref_alive? && @weak_liquid_drop.__getobj__
+          unless drop
+            drop = liquify_dynamically
+            @weak_liquid_drop = WeakRef.new(drop)
+          end
+          drop
         end
 
         ## Solidify
@@ -33,9 +39,8 @@ module Lesmok
         # or use generic AcidDrop if it can't be found.
         #
         def liquify_dynamically
-          return @liquid_drop if @liquid_drop
           klass = liquify_drop_klass || AcidDrop
-          @liquid_drop = klass.new(self)
+          klass.new(self)
         end
 
         ##

--- a/lib/lesmok/acid/meltable.rb
+++ b/lib/lesmok/acid/meltable.rb
@@ -21,7 +21,11 @@ module Lesmok
 
         ## Liquify...
         def to_liquid
-          drop = @weak_liquid_drop && @weak_liquid_drop.weakref_alive? && @weak_liquid_drop.__getobj__
+          drop = begin
+            @weak_liquid_drop && @weak_liquid_drop.weakref_alive? && @weak_liquid_drop.__getobj__
+          rescue ::WeakRef::RefError => e
+            nil # Catch this due to a minor race condition possibility above.
+          end
           unless drop
             drop = liquify_dynamically
             @weak_liquid_drop = WeakRef.new(drop)


### PR DESCRIPTION
Bi-directional memoization on both the source object and the liquid drop can easily cause long chains and/or circular object references. While this isn't a problem in GC'd languages, any single object references within that chain could easily keep the whole lot non-GC'd.

By making the memoization a weak-ref for the `to_liquid` case, this becomes a much smaller issue. However, it means you risk "lost state" in the `Drop` object if that in turn has memoized something.
